### PR TITLE
Introduce saga coordination logic for the first time.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # Debian
 FROM python:3.8.1-buster
 
-RUN apt-get update -y
-
 ADD src/ .
 
 RUN pip3 install -r requirements.txt
 
-CMD python3 qbox.py
+CMD python3 server.py

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 local-development:
-	docker build -t qbox .  && docker run -it -p 80:80 qbox
+	docker build -t qbox .  && docker run -it -p 80:3001 qbox
+
+run-local-tests:
+	black .
+	docker build -t qbox .  && docker run -it qbox python3 -m unittest discover 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,0 +1,111 @@
+""" 
+This file defines the structure of the configuration Qbox uses. 
+
+We perform schema validation for the entire configuration. This is 
+basically the power of protobufs without needing to use protobufs. We
+use the schema library (https://github.com/keleshev/schema) for this.
+
+See configuration_test.py for example configurations.
+"""
+import os
+import yaml
+from schema import Schema, And, Or, Optional, Const
+
+CONFIGURATION_PATH = "configuration/config.yaml"
+
+# All messages need to have a source address and a destination address.
+# These addresses should resolve using cluster DNS.
+# Messages may optionally include a list of headers as string key/value pairs.
+# and an optional body. How these headers and bodies are included in new values
+# is dependent on where the message is defined in the schema - `matchRequest` messages
+# have different behaviour than `onFailue` messages.
+HTTP_REQUEST_SCHEMA = Schema(
+    {
+        "method": lambda t: t in ["GET", "HEAD", "PUT", "PATCH", "DELETE", "POST"],
+        "url": str,
+        Optional("headers"): Schema(Or({str: str}, {})),
+        Optional("body"): str,
+    },
+    ignore_extra_keys=True,
+)
+
+HTTP_RESPONSE_SCHEMA = Schema(
+    {
+        "status-code": int,
+        Optional("headers"): Schema(Or({str: str}, {})),
+        Optional("body"): str,
+    },
+    ignore_extra_keys=True,
+)
+
+# Some messages are part of a transaction. Such transactions need to specify a timeout,
+# a number of times to retry on a timeout, and a compensating transaction (marked in "onFailure").
+#
+# Messages in `onFailure` will always inherit headers/bodies from their parent message - if headers
+# and bodies are specified under `onFailure`, then headers will be upserted and bodies will be
+# overwritten.
+#
+# Messages in `matchSuccessRequest` are what responses are compared to to mark the transaction
+# as succeeded. Any response that does not match that criteria is automatic grounds for the
+# transaction as a whole to fail.
+
+COMPENSATING_TRANSACTION_SCHEMA = And(
+    Const(
+        HTTP_REQUEST_SCHEMA,
+        Schema(
+            {
+                "timeout": And(int, lambda timeout: timeout >= 0),
+                Optional("maxRetriesOnTimeout"): And(
+                    int, lambda maxRetries: maxRetries >= 0
+                ),
+                "isSuccessIfReceives": Schema([HTTP_RESPONSE_SCHEMA]),
+            },
+            ignore_extra_keys=True,
+        ),
+    ),
+)
+
+TRANSACTION_SCHEMA = And(
+    Const(
+        HTTP_REQUEST_SCHEMA,
+        Schema(
+            {
+                "timeout": And(int, lambda timeout: timeout >= 0),
+                Optional("maxRetriesOnTimeout"): And(
+                    int, lambda maxRetries: maxRetries >= 0
+                ),
+                "onFailure": Schema([COMPENSATING_TRANSACTION_SCHEMA]),
+                "isSuccessIfReceives": Schema([HTTP_RESPONSE_SCHEMA]),
+            },
+            ignore_extra_keys=True,
+        ),
+    ),
+)
+
+# The root of our configuration. The list of headers, bodies, etc. supplied in `matchRequest`
+# will be used to match the request to initiate the saga workflow.
+ROOT_SCHEMA = Schema(
+    {
+        "host": str,
+        "matchRequest": HTTP_REQUEST_SCHEMA,
+        "onMatchedRequest": Schema([TRANSACTION_SCHEMA]),
+        Optional("onAllSucceeded"): HTTP_REQUEST_SCHEMA,
+    },
+    ignore_extra_keys=True,
+)
+
+
+class Configuration(object):
+    """
+    This manager pulls configuration artifacts from a mounted directory called `configuration`.
+    The directory mounting in production is handled by Kubernetes ConfigMaps. 
+    """
+
+    def __init__(self):
+
+        with open(CONFIGURATION_PATH) as config:
+            self.config = ROOT_SCHEMA.validate(yaml.load(config))
+
+    def get_config(self):
+
+        return self.config

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -1,0 +1,156 @@
+import uuid
+import requests
+import itertools
+from requests.exceptions import Timeout
+
+# TODO: Make this configurable
+ENVOY_ADDRESS = "127.0.0.1:15001"
+
+
+class SagaCoordinator(object):
+    """
+    A class that handles initiating transactions, and failing all of them
+    if one of them fails.
+    """
+
+    def __init__(self, configuration):
+        self.configuration = configuration
+        self.identifier = uuid.uuid4()
+
+    def execute_saga(self, parent_headers={}):
+        """
+        Perform a serial unicast over the set of transactions. If any of them
+        fail, halt sending out more transactions, and issue compensating transactions
+        for all of the transactions sent out so far.
+
+        Returns:
+            - `success`: Bool -> Whether all of the transactions succeeded without 
+                                 incident.
+
+            - `transactions_so_far`: List[(Dict, Dict)] -> 
+                                All of the transactions that completed 
+                                of whose unsuccessful response triggered us to issue 
+                                compensating transactions. A transaction in the latter
+                                category will always be found at the end of this list.
+                                Each element in this list is a tuple of (headers sent
+                                out in that transaction, the transaction configuration).
+
+            - `failed_compensating_transactions` - List[(Dict, Response)] -> 
+                                All of the compensating transactions that did not work.
+                                By default, we keep retrying a compensating transaction
+                                indefinitely unless a max retry is set. Each element in
+                                this list is a tuple of (compensating transaction config,
+                                the last response that transaction received).
+        """
+
+        transactions = self.configuration["onMatchedRequest"]
+        transactions_so_far = []
+
+        for transaction in transactions:
+            headers, response = self.send(
+                transaction, kind="TRANSACTION", parent_headers=parent_headers
+            )
+            transactions_so_far.append((headers, transaction))
+
+            if self.is_successful(response, transaction["isSuccessIfReceives"]):
+                continue
+            else:
+                return (
+                    False,
+                    transactions_so_far,
+                    self.issue_compensating_transactions(transactions_so_far),
+                )
+
+        return True, transactions_so_far, []
+
+    def issue_compensating_transactions(self, transactions_so_far):
+
+        failed_compensations = []
+
+        for headers, transaction in transactions_so_far:
+            for compensating_transaction in transaction["onFailure"]:
+                _, response = self.send(
+                    compensating_transaction,
+                    kind="COMPENSATION",
+                    parent_headers=headers,
+                )
+
+                if self.is_successful(
+                    response, compensating_transaction["isSuccessIfReceives"]
+                ):
+                    continue
+
+                else:
+                    failed_compensations.append((compensating_transaction, response))
+
+        return failed_compensations
+
+    def is_successful(self, response, expected_responses):
+        """
+        Check if the response that was received matches one of the 
+        ones we were waiting for
+        """
+
+        if not response:
+            return False
+
+        for expected_response in expected_responses:
+
+            if response.status_code != expected_response["status-code"]:
+                continue
+
+            if expected_response.get("headers", {}) and any(
+                response.headers.get(header) != value
+                for header, value in expected_response["headers"].items()
+            ):
+                continue
+
+            if (
+                expected_response.get("body", None)
+                and response.text != expected_response["body"]
+            ):
+                continue
+
+            return True
+
+        return False
+
+    def send(self, transaction, kind="TRANSACTION", parent_headers=None):
+        """ 
+        Handle the complete lifecycle of a single transaction.
+        """
+
+        headers = parent_headers or {}
+        headers.update(
+            {"X-Qbox-TransactionID": self.identifier, "X-Qbox-Message-Type": kind}
+        )
+        headers.update(transaction.get("headers", {}))
+
+        body = transaction.get("body", None)
+
+        # IF the number of retries is not specified:
+        #  - Always keep retrying compensating transactions unless one succeeds.
+        #  - Cap the number of retries for transactions to just one.
+        # This ensures safety for other services.
+        maxIterations = transaction.get(
+            "maxRetriesOnTimeout", None if kind == "COMPENSATION" else 1
+        )
+
+        for _ in itertools.repeat(0, times=maxIterations):
+
+            response = None
+            try:
+                response = requests.request(
+                    method=transaction["method"],
+                    url=transaction["url"],
+                    headers=transaction,
+                    data=transaction,
+                    timeout=transaction["timeout"],
+                    proxies={"http": ENVOY_ADDRESS, "https": ENVOY_ADDRESS},
+                )
+            except Timeout:
+                continue
+
+            return headers, response
+
+        return headers, None

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,1 +1,5 @@
 aiohttp==3.6.2
+schema==0.7.1
+PyYAML==5.3.1
+requests==2.9.1
+requests-mock==1.7.0

--- a/src/server.py
+++ b/src/server.py
@@ -2,11 +2,15 @@ import signal
 import asyncio
 import logging
 from aiohttp import web
+from configuration import ConfigurationManager
 
 logging.basicConfig(level=logging.INFO)
 
-ADDRESS = '0.0.0.0'
-PORT = 80
+ADDRESS = "0.0.0.0"
+PORT = 3001
+
+configuration = ConfigurationManager().get_config()
+
 
 async def main(loop):
     """
@@ -14,22 +18,20 @@ async def main(loop):
     the event loop. It is safe to let this coroutine die in a loop that's running
     forever. 
     """
+
     runner = web.ServerRunner(web.Server(handler))
     await runner.setup()
     site = web.TCPSite(runner, ADDRESS, PORT)
     await site.start()
 
+
 async def handler(request):
     """
-    Handle all requests as deemed necessary. 
+    Handle all requests as deemed necessary.
     """
 
-    logging.info("Received a request!")
-    # this is just a placeholder for now. You can hit this at localhost:80 if you run the Makefile. 
-    # We need to expand this to something more complicated that can handle proxying.
-    return web.Response(text="OK")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
     loop.create_task(main(loop))

--- a/src/test_configuration.py
+++ b/src/test_configuration.py
@@ -1,0 +1,170 @@
+import yaml
+import unittest
+from schema import SchemaError
+from unittest.mock import patch, mock_open
+from configuration import (
+    ROOT_SCHEMA,
+    TRANSACTION_SCHEMA,
+    HTTP_REQUEST_SCHEMA,
+    HTTP_RESPONSE_SCHEMA,
+    Configuration,
+    CONFIGURATION_PATH,
+)
+
+
+class TestConfiguration(unittest.TestCase):
+    def testValidRequestsSchema(self):
+
+        validRequests = [
+            {"method": "GET", "url": "foo"},
+            {"method": "POST", "url": "bar"},
+            {"method": "PUT", "url": "foobar"},
+            {"method": "PATCH", "url": "foo"},
+            {"method": "DELETE", "url": "delete"},
+            {"method": "HEAD", "url": "delete"},
+            {"method": "GET", "url": "bar", "headers": {"example": "yo"}},
+            {
+                "method": "POST",
+                "url": "bar",
+                "headers": {"example": "yo"},
+                "body": "blahblah",
+            },
+        ]
+
+        for message in validRequests:
+            HTTP_REQUEST_SCHEMA.validate(message)
+
+    def testValidResponseSchema(self):
+
+        validResponses = [
+            {"status-code": 200, "url": "foo"},
+            {"status-code": 200, "url": "foo", "headers": {"la": "la"}},
+            {
+                "status-code": 200,
+                "url": "foo",
+                "headers": {"la": "la"},
+                "body": "fangrubber",
+            },
+        ]
+
+        for message in validResponses:
+            HTTP_RESPONSE_SCHEMA.validate(message)
+
+    def testValidTransactionSchema(self):
+
+        validTransaction = {
+            "method": "GET",
+            "url": "destination",
+            "headers": {
+                "X-Qbox-Transaction": "1",
+                "X-Qbox-Status": "INITIATE-TRANSACTION",
+            },
+            "onFailure": [
+                {
+                    "method": "POST",
+                    "url": "destination",
+                    "headers": {
+                        "X-Qbox-Transaction": "1",
+                        "X-Qbox-Status": "COMPENSATE-TRANSACTION",
+                    },
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 300,
+                    "isSuccessIfReceives": [{"status-code": 200}],
+                }
+            ],
+            "isSuccessIfReceives": [{"status-code": 200}],
+            "timeout": 30,
+            "maxRetriesOnTimeout": 3,
+        }
+
+        TRANSACTION_SCHEMA.validate(validTransaction)
+
+    def test_valid_root_schema(self):
+
+        validRoot = {
+            "host": "me.svc",
+            "matchRequest": {
+                "method": "GET",
+                "url": "qbox.me.svc",
+                "headers": {"Hey-Qbox": "Begin-Transaction"},
+            },
+            "onMatchedRequest": [
+                {
+                    "method": "POST",
+                    "url": "foo.svc",
+                    "headers": {"custom": "value"},
+                    "onFailure": [
+                        {
+                            "method": "POST",
+                            "url": "foo.svc",
+                            "headers": {
+                                # Commented out headers are automatically populated by Qbox
+                                # and are shown here for demonstration purposes of the final output
+                                # "X-Qbox-Transaction": "1"
+                                # "X-Qbox-Status": "COMPENSATE-TRANSACTION"
+                                # "Hey-Qbox": "Begin-Transaction"
+                                # "custom": "value"
+                            },
+                            "timeout": 30,
+                            "isSuccessIfReceives": [{"status-code": 200}],
+                        }
+                    ],
+                    "isSuccessIfReceives": [{"status-code": 200}],
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 3,
+                }
+            ],
+            "onAllSucceeded": {"method": "GET", "url": "qbox"},
+        }
+
+        ROOT_SCHEMA.validate(validRoot)
+
+
+class TestConfigurationManager(unittest.TestCase):
+
+    validRoot = {
+        "host": "me.svc",
+        "matchRequest": {
+            "method": "GET",
+            "url": "qbox.me.svc",
+            "headers": {"Hey-Qbox": "Begin-Transaction"},
+        },
+        "onMatchedRequest": [
+            {
+                "method": "POST",
+                "url": "foo.svc",
+                "headers": {"custom": "value"},
+                "onFailure": [
+                    {
+                        "method": "POST",
+                        "url": "foo.svc",
+                        "headers": {
+                            # Commented out headers are automatically populated by Qbox
+                            # and are shown here for demonstration purposes of the final output
+                            # "X-Qbox-Transaction": "1"
+                            # "X-Qbox-Status": "COMPENSATE-TRANSACTION"
+                            # "Hey-Qbox": "Begin-Transaction"
+                            # "custom": "value"
+                        },
+                        "timeout": 30,
+                        "isSuccessIfReceives": [{"status-code": 200}],
+                    }
+                ],
+                "isSuccessIfReceives": [{"status-code": 200}],
+                "timeout": 30,
+                "maxRetriesOnTimeout": 3,
+            }
+        ],
+        "onAllSucceeded": {"method": "GET", "url": "me.svc"},
+    }
+
+    def test_get_config(self):
+
+        with patch(
+            "builtins.open", mock_open(read_data=yaml.dump(self.validRoot))
+        ) as mock_file:
+            configuration = Configuration().get_config()
+
+            mock_file.assert_called_with(CONFIGURATION_PATH)
+            self.assertIn("matchRequest", configuration)
+            self.assertIn("onMatchedRequest", configuration)

--- a/src/test_coordinator.py
+++ b/src/test_coordinator.py
@@ -1,0 +1,74 @@
+import unittest
+import requests_mock
+from coordinator import SagaCoordinator
+
+
+class TestSagaCoordinator(unittest.TestCase):
+    def test_saga_sends(self):
+
+        configuration = {
+            "host": "me.svc",
+            "matchRequest": {
+                "method": "GET",
+                "url": "qbox.me.svc",
+                "headers": {"Hey-Qbox": "Begin-Transaction"},
+            },
+            "onMatchedRequest": [
+                {
+                    "method": "POST",
+                    "url": "http://foo.svc/transact",
+                    "headers": {"custom": "value"},
+                    "onFailure": [
+                        {
+                            "method": "POST",
+                            "url": "http://foo.svc/fail",
+                            "headers": {},
+                            "timeout": 3,
+                            "maxRetriesOnTimeout": 1,
+                            "isSuccessIfReceives": [{"status-code": 200}],
+                        }
+                    ],
+                    "isSuccessIfReceives": [{"status-code": 200}],
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 3,
+                }
+            ],
+            "onAllSucceeded": {"method": "GET", "url": "me.svc"},
+        }
+
+        coordinator = SagaCoordinator(configuration)
+
+        with requests_mock.Mocker() as m:
+            m.post("http://foo.svc/transact", status_code=200)
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                ["http://foo.svc/transact"],
+                [request.url for request in m.request_history],
+            )
+            self.assertTrue(success)
+            self.assertEqual(len(transactions), 1)
+            self.assertEqual(len(failed_compensations), 0)
+
+        with requests_mock.Mocker() as m:
+            m.post("http://foo.svc/transact", status_code=404)
+            m.post("http://foo.svc/fail", status_code=200)
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                ["http://foo.svc/transact", "http://foo.svc/fail"],
+                [request.url for request in m.request_history],
+            )
+            self.assertFalse(success)
+            self.assertEqual(len(transactions), 1)
+            self.assertEqual(len(failed_compensations), 0)
+
+        with requests_mock.Mocker() as m:
+            m.post("http://foo.svc/transact", status_code=404)
+            m.post("http://foo.svc/fail", status_code=403)
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                ["http://foo.svc/transact", "http://foo.svc/fail"],
+                [request.url for request in m.request_history],
+            )
+            self.assertFalse(success)
+            self.assertEqual(len(transactions), 1)
+            self.assertEqual(len(failed_compensations), 1)


### PR DESCRIPTION
This commit:

- Drops the state machine model introduced in
https://github.com/Brown-CS2952-cwu-amahajan/qbox/pull/2. Instead, we
implement a raw execution engine that is closely coupled to
configuration specifics.

- Revamps the configuration model. Instead of specifying states for the
state machine, we introduce conventions to match requests, a template
for generating requests, and guarantees on header inheritance by
compensating transactions.

- Introduces a `SagaCoordinator` class that fully respects timeouts, and
can issue compensating transactions when some response fails.

- Introduces unit tests and schema validation for configuration as well
as the `SagaCoordinator` class, including network requests mocking.

This is a fairly large commit, but our work isn't done yet:

- We still need to figure out traffic redirection logic between Envoy, application
and the qbox in the next two weeks.

- The tests are incomplete, and only test basic saga logic. It doesn't
test any of the guarantees we will actually need, such as ensuring
headers propagate correctly from parent transaction to child
compensating transaction.

- There is no suppot for asynchronous saga requests. Everything is
synchronous or nothing. We should revisit this at a later date - for
now, I am fine just keeping everything synchronous for simplicity.

- We still need to build out the `handler` logic in `server.py` to
interface with the `SagaCoordinator`. One thing I want to do is either
create a new process to run `SagaCoordinator` in or add a coordinator to
our event loop, so that the main loop isn't blocked.