### PR TITLE
Add support for interpolation and implement server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-local-development:
-	docker build -t qbox .  && docker run -it -p 80:3001 qbox
-
-run-local-tests:
+lint:
 	black .
-	docker build -t qbox .  && docker run -it qbox python3 -m unittest discover
+
+local-inspect: lint
+	docker build -t qbox:latest .  && docker run -it -p 3001:3001 qbox /bin/bash
+
+local-development: lint
+	docker build -t qbox:latest .  && docker run -it -p 3001:3001 qbox
+
+run-local-tests: lint
+	docker build -t qbox:latest .  && docker run -it qbox python3 -m unittest discover
+
+push-to-dockerhub: lint run-local-tests
+	docker tag qbox akshatm/qbox:latest
+	docker push akshatm/qbox:latest

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ local-development:
 
 run-local-tests:
 	black .
-	docker build -t qbox .  && docker run -it qbox python3 -m unittest discover 
+	docker build -t qbox .  && docker run -it qbox python3 -m unittest discover

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -6,7 +6,7 @@ from interpolate import interpolate
 from requests.exceptions import Timeout
 
 # TODO: Make this configurable
-ENVOY_ADDRESS = "127.0.0.1:15001"
+ENVOY_ADDRESS = "http://127.0.0.1:15001"
 
 
 class RequestNode(object):

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -1,10 +1,51 @@
+import re
 import uuid
 import requests
 import itertools
+from interpolate import interpolate
 from requests.exceptions import Timeout
 
 # TODO: Make this configurable
 ENVOY_ADDRESS = "127.0.0.1:15001"
+
+
+class RequestNode(object):
+    def __init__(self):
+        self.url = None
+        self.headers = {}
+        self.body = ""
+        self.children = []
+        self.parent = None
+        self.response_status = None
+        self.response_headers = {}
+        self.response_body = ""
+        self.configuration = {}
+
+    def add_parent(self, parent):
+        parent.children.append(self)
+        self.parent = parent
+
+    def update_request(self, **kwargs):
+        if "url" in kwargs:
+            self.url = kwargs["url"]
+        if "headers" in kwargs:
+            self.headers = kwargs["headers"]
+
+        if "body" in kwargs:
+            self.body = kwargs["body"]
+
+    def update_response(self, **kwargs):
+        if "headers" in kwargs:
+            self.response_headers = kwargs["headers"]
+
+        if "body" in kwargs:
+            self.response_body = kwargs["body"]
+
+        if "status" in kwargs:
+            self.response_status = kwargs["status"]
+
+    def update_configuration(self, configuration={}):
+        self.configuration = configuration
 
 
 class SagaCoordinator(object):
@@ -13,11 +54,14 @@ class SagaCoordinator(object):
     if one of them fails.
     """
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, start_request_headers={}, start_request_body=""):
         self.configuration = configuration
-        self.identifier = uuid.uuid4()
+        self.identifier = str(uuid.uuid4())
+        self.root = RequestNode()
+        self.root.update_configuration(self.configuration.get("matchRequest", {}))
+        self.root.update_request(headers=start_request_headers, body=start_request_body)
 
-    def execute_saga(self, parent_headers={}):
+    def execute_saga(self):
         """
         Perform a serial unicast over the set of transactions. If any of them
         fail, halt sending out more transactions, and issue compensating transactions
@@ -44,89 +88,95 @@ class SagaCoordinator(object):
         """
 
         transactions = self.configuration["onMatchedRequest"]
-        transactions_so_far = []
 
         for transaction in transactions:
-            headers, response = self.send(
-                transaction, kind="TRANSACTION", parent_headers=parent_headers
-            )
-            transactions_so_far.append((headers, transaction))
+            node = self.send(transaction, kind="TRANSACTION", parent=self.root)
 
-            if self.is_successful(response, transaction["isSuccessIfReceives"]):
+            if self.is_successful(node, transaction["isSuccessIfReceives"]):
+                node.add_parent(self.root)
                 continue
             else:
                 return (
                     False,
-                    transactions_so_far,
-                    self.issue_compensating_transactions(transactions_so_far),
+                    self.root.children,
+                    self.issue_compensating_transactions(self.root.children),
                 )
 
-        return True, transactions_so_far, []
+        return True, self.root.children, []
 
     def issue_compensating_transactions(self, transactions_so_far):
 
         failed_compensations = []
 
-        for headers, transaction in transactions_so_far:
-            for compensating_transaction in transaction["onFailure"]:
-                _, response = self.send(
-                    compensating_transaction,
-                    kind="COMPENSATION",
-                    parent_headers=headers,
+        for node in transactions_so_far:
+            for compensating_transaction in node.configuration["onFailure"]:
+
+                response_node = self.send(
+                    compensating_transaction, kind="COMPENSATION", parent=node
                 )
 
                 if self.is_successful(
-                    response, compensating_transaction["isSuccessIfReceives"]
+                    response_node, compensating_transaction["isSuccessIfReceives"]
                 ):
+                    response_node.add_parent(node)
                     continue
 
                 else:
-                    failed_compensations.append((compensating_transaction, response))
+                    failed_compensations.append(response_node)
 
         return failed_compensations
 
-    def is_successful(self, response, expected_responses):
+    def is_successful(self, node, expected_responses):
         """
         Check if the response that was received matches one of the 
         ones we were waiting for
         """
 
-        if not response:
+        if not node.response_status:
             return False
 
         for expected_response in expected_responses:
 
-            if response.status_code != expected_response["status-code"]:
+            _, headers, body = self.resolve_interpolations(
+                expected_response, parent=node
+            )
+
+            if node.response_status != expected_response["status-code"]:
                 continue
 
-            if expected_response.get("headers", {}) and any(
-                response.headers.get(header) != value
-                for header, value in expected_response["headers"].items()
+            if headers and any(
+                node.response_headers.get(header) != value
+                for header, value in headers.items()
             ):
                 continue
 
-            if (
-                expected_response.get("body", None)
-                and response.text != expected_response["body"]
-            ):
+            if body and node.response_body != body:
                 continue
 
             return True
 
         return False
 
-    def send(self, transaction, kind="TRANSACTION", parent_headers=None):
+    def prepare_node(self, transaction, parent, kind):
+
+        url, headers, body = self.resolve_interpolations(transaction, parent=parent)
+
+        headers.update(
+            {"X-Qbox-TransactionID": self.identifier, "X-Qbox-Message-Type": kind}
+        )
+
+        node = RequestNode()
+        node.update_configuration(transaction)
+        node.update_request(url=url, headers=headers, body=body)
+
+        return node
+
+    def send(self, transaction, kind="TRANSACTION", parent=None):
         """ 
         Handle the complete lifecycle of a single transaction.
         """
 
-        headers = parent_headers or {}
-        headers.update(
-            {"X-Qbox-TransactionID": self.identifier, "X-Qbox-Message-Type": kind}
-        )
-        headers.update(transaction.get("headers", {}))
-
-        body = transaction.get("body", None)
+        node = self.prepare_node(transaction, parent, kind)
 
         # IF the number of retries is not specified:
         #  - Always keep retrying compensating transactions unless one succeeds.
@@ -142,15 +192,37 @@ class SagaCoordinator(object):
             try:
                 response = requests.request(
                     method=transaction["method"],
-                    url=transaction["url"],
-                    headers=transaction,
-                    data=transaction,
+                    url=node.url,
+                    headers=node.headers,
+                    data=node.body,
                     timeout=transaction["timeout"],
                     proxies={"http": ENVOY_ADDRESS, "https": ENVOY_ADDRESS},
                 )
             except Timeout:
                 continue
 
-            return headers, response
+            node.update_response(
+                status=response.status_code,
+                headers=response.headers,
+                body=response.text,
+            )
+            return node
 
-        return headers, None
+        return node
+
+    def resolve_interpolations(self, transaction, parent=None):
+
+        url = None
+        if "url" in transaction:
+            url = self.interpolate(transaction["url"], parent=parent)
+
+        headers = transaction.get("headers", {})
+        for header, value in headers.items():
+            headers[header] = self.interpolate(value, parent=parent)
+
+        body = self.interpolate(transaction.get("body", ""), parent=parent)
+
+        return url, headers, body
+
+    def interpolate(self, line, parent):
+        return interpolate(line, parent=parent, root=self.root, transactions=[])

--- a/src/interpolate.py
+++ b/src/interpolate.py
@@ -1,0 +1,95 @@
+import re
+
+
+def interpolate(line, parent, root, transactions):
+    """
+    Replace an interpolation pattern with the corresponding values.
+    """
+
+    if not line:
+        return line
+
+    def replace_root_headers(match):
+        header, default = match.groups()
+        return root.headers.get(header, default)
+
+    def replace_root_body(match):
+        default = match.group("default")
+        return root.body if root.body else default
+
+    def replace_parent_headers(match):
+        header, default = match.groups()
+        return parent.headers.get(header, default)
+
+    def replace_parent_response_headers(match):
+        header, default = match.groups()
+        return parent.response_headers.get(header, default)
+
+    def replace_parent_response_body(match):
+        default = match.groups("default")
+        return parent.response_body if parent.response_body else default
+
+    def replace_parent_body(match):
+        default = match.groups("default")
+        return parent.body if parent.body else default
+
+    def replace_transaction_request_headers(match):
+        index, header, default = match.groups()
+        index = int(index)
+
+        if 0 <= index < len(transactions):
+            return (
+                transactions[index]
+                .get("request", {})
+                .get("headers", {})
+                .get(header, default)
+            )
+        else:
+            return default
+
+    def replace_transaction_response_headers(match):
+        index, header, default = match.groups()
+        index = int(index)
+
+        if 0 <= index < len(transactions):
+            return transactions[index].response_headers.get(header, default)
+        else:
+            return default
+
+    def replace_transaction_request_body(match):
+        index, default = match.groups()
+        index = int(index)
+
+        if 0 <= index < len(transactions):
+            body = transactions[index].body
+            return default if not body else body
+        else:
+            return default
+
+    def replace_transaction_response_body(match):
+        index, default = match.groups()
+        index = int(index)
+
+        if 0 <= index < len(transactions):
+            body = transactions[index].response_body
+            return default if not body else body
+        else:
+            return default
+
+    patterns = {
+        r"\$\{root\.headers\.(?P<header>[A-Za-z0-9\_\-]+):?(?P<default>.*?)\}": replace_root_headers,
+        r"\$\{root\.body:?(?P<default>.*?)\}": replace_root_body,
+        r"\$\{parent\.headers\.(?P<header>[A-Za-z0-9\_\-]+):?(?P<default>.*?)\}": replace_parent_headers,
+        r"\$\{parent\.body:?(?P<default>.*?)\}": replace_parent_body,
+        r"\$\{parent\.response\.headers\.(?P<header>[A-Za-z0-9\_\-]+):?(?P<default>.*?)\}": replace_parent_response_headers,
+        r"\$\{parent\.response\.body:?(?P<default>.*?)\}": replace_parent_response_body,
+        r"\$\{transaction\[(?P<index>[0-9]+)\]\.request\.headers\.(?P<header>[A-Za-z0-9\_\-]+):?(?P<default>.*?)\}": replace_transaction_request_headers,
+        r"\$\{transaction\[(?P<index>[0-9]+)\]\.response\.headers\.(?P<header>[A-Za-z0-9\_\-]+):?(?P<default>.*?)\}": replace_transaction_response_headers,
+        r"\$\{transaction\[(?P<index>[0-9]+)\]\.request\.body:?(?P<default>.*?)\}": replace_transaction_request_body,
+        r"\$\{transaction\[(?P<index>[0-9]+)\]\.response\.body:?(?P<default>.*?)\}": replace_transaction_response_body,
+    }
+
+    for pattern, replacement_function in patterns.items():
+        line = re.sub(pattern, replacement_function, line, flags=re.IGNORECASE)
+
+    return line

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
-aiohttp==3.6.2
 schema==0.7.1
 PyYAML==5.3.1
 requests==2.9.1
 requests-mock==1.7.0
+requests-toolbelt==0.9.1
+scapy==2.4.3

--- a/src/server.py
+++ b/src/server.py
@@ -1,46 +1,144 @@
-import signal
-import asyncio
 import logging
-from aiohttp import web
-from configuration import ConfigurationManager
+import requests
+from functools import partial
+from interpolate import interpolate
+from configuration import ConfigurationStore
+from coordinator import SagaCoordinator, RequestNode, ENVOY_ADDRESS
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
 
 logging.basicConfig(level=logging.INFO)
 
 ADDRESS = "0.0.0.0"
 PORT = 3001
 
-configuration = ConfigurationManager().get_config()
 
+class RequestHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super(RequestHandler, self).__init__(*args, **kwargs)
+        self.body = None
+        self.configuration = ConfigurationStore().get_config()
 
-async def main(loop):
-    """
-    This coroutine initiates our server as subsequent asyncio.Tasks on 
-    the event loop. It is safe to let this coroutine die in a loop that's running
-    forever. 
-    """
+    def do_GET(self):
+        return self.handle_connection()
 
-    runner = web.ServerRunner(web.Server(handler))
-    await runner.setup()
-    site = web.TCPSite(runner, ADDRESS, PORT)
-    await site.start()
+    def do_POST(self):
+        return self.handle_connection()
 
+    def do_PUT(self):
+        return self.handle_connection()
 
-async def handler(request):
-    """
-    Handle all requests as deemed necessary.
-    """
+    def do_PATCH(self):
+        return self.handle_connection()
+
+    def do_DELETE(self):
+        return self.handle_connection()
+
+    def do_OPTIONS(self):
+        return self.handle_connection()
+
+    def do_HEAD(self):
+        return self.handle_connection()
+
+    def do_TRACE(self):
+        return self.handle_connection()
+
+    def do_CONNECT(self):
+        return self.handle_connection()
+
+    def get_body(self):
+        if self.body:
+            return self.body
+        body = self.rfile.read()
+        self.body = body
+        return self.body
+
+    def handle_connection(self):
+        if self.configuration and self.is_saga_request():
+            status, headers, body = self.execute()
+            self.send_response(status)
+            for header, value in headers.items():
+                self.send_header(header, value)
+            self.end_headers()
+            self.wfile.write(body.encode("utf-8"))
+        else:
+            url = self.headers["Host"]
+            try:
+                response = requests.request(
+                    method=self.command,
+                    # NOTE: We're assuming HTTPS traffic is never sent to us!
+                    # This is fine for our proof-of-concept - Envoy in practice
+                    # automatically upgrades all HTTP traffic to HTTPS if configured
+                    # to do so with the appropriate TLS certificates.
+                    url=url if url.startswith("http://") else f"http://{url}",
+                    headers=self.headers,
+                    data=self.get_body(),
+                    proxies={"http": ENVOY_ADDRESS, "https": ENVOY_ADDRESS},
+                )
+                self.send_response(response.status_code)
+                for header, value in response.headers.items():
+                    self.send_header(header, value)
+                self.end_headers()
+                self.wfile.write(response.content)
+            except Exception as e:
+                self.send_error(599, "Error proxying: {}".format(e))
+
+    def is_saga_request(self):
+
+        config = self.configuration["matchRequest"]
+        headers = config.get("headers", {})
+        body = config.get("body", "")
+
+        constructed_url = f"{self.headers['Host']}{self.path}"
+        if not constructed_url.startswith("http://"):
+            constructed_url = f"http://{constructed_url}"
+
+        if config["url"] != constructed_url:
+            return False
+        if config["method"] != self.command:
+            return False
+        if headers and any(
+            self.headers.get(header) != value for header, value in headers.items()
+        ):
+            return False
+        if body and self.get_body() != body:
+            return False
+
+        return True
+
+    def execute(self):
+        """
+        Handle all requests as deemed necessary.
+        """
+
+        coordinator = SagaCoordinator(
+            self.configuration,
+            start_request_headers=self.headers,
+            start_request_body=self.get_body(),
+        )
+        success, transactions, failed_compensations = coordinator.execute_saga()
+        context = {
+            "parent": RequestNode(),
+            "root": coordinator.root,
+            "transactions": transactions,
+        }
+
+        if success:
+            return self.respond(self.configuration["onAllSucceeded"], context)
+        else:
+            return self.respond(self.configuration["onAnyFailed"], context)
+
+    def respond(self, config, context):
+
+        headers = {}
+        for header, value in config.get("headers", {}):
+            headers[header] = interpolate(value, **context)
+        body = interpolate(config.get("body", ""), **context)
+        return config["status-code"], headers, body
 
 
 if __name__ == "__main__":
 
-    loop = asyncio.get_event_loop()
-    loop.create_task(main(loop))
-    logging.info("Initialized Qbox! Now serving...")
+    config = ConfigurationStore().get_config()
 
-    try:
-        loop.run_forever()
-    except KeyboardInterrupt:
-        pass
-    finally:
-        loop.stop()
-        loop.close()
+    httpd = ThreadingHTTPServer((ADDRESS, PORT), RequestHandler)
+    httpd.serve_forever()

--- a/src/test_configuration.py
+++ b/src/test_configuration.py
@@ -7,7 +7,7 @@ from configuration import (
     TRANSACTION_SCHEMA,
     HTTP_REQUEST_SCHEMA,
     HTTP_RESPONSE_SCHEMA,
-    Configuration,
+    ConfigurationStore,
     CONFIGURATION_PATH,
 )
 
@@ -114,7 +114,7 @@ class TestConfiguration(unittest.TestCase):
                     "maxRetriesOnTimeout": 3,
                 }
             ],
-            "onAllSucceeded": {"method": "GET", "url": "qbox"},
+            "onAllSucceeded": {"status-code": 200},
         }
 
         ROOT_SCHEMA.validate(validRoot)
@@ -155,7 +155,8 @@ class TestConfigurationManager(unittest.TestCase):
                 "maxRetriesOnTimeout": 3,
             }
         ],
-        "onAllSucceeded": {"method": "GET", "url": "me.svc"},
+        "onAllSucceeded": {"status-code": 200},
+        "onAnyFailed": {"status-code": 200},
     }
 
     def test_get_config(self):
@@ -163,7 +164,10 @@ class TestConfigurationManager(unittest.TestCase):
         with patch(
             "builtins.open", mock_open(read_data=yaml.dump(self.validRoot))
         ) as mock_file:
-            configuration = Configuration().get_config()
+
+            with patch("os.path.exists") as os_mock:
+                os_mock.return_value = True
+                configuration = ConfigurationStore().get_config()
 
             mock_file.assert_called_with(CONFIGURATION_PATH)
             self.assertIn("matchRequest", configuration)

--- a/src/test_coordinator.py
+++ b/src/test_coordinator.py
@@ -1,6 +1,7 @@
 import unittest
 import requests_mock
-from coordinator import SagaCoordinator
+from interpolate import interpolate
+from coordinator import SagaCoordinator, RequestNode
 
 
 class TestSagaCoordinator(unittest.TestCase):
@@ -33,13 +34,12 @@ class TestSagaCoordinator(unittest.TestCase):
                     "maxRetriesOnTimeout": 3,
                 }
             ],
-            "onAllSucceeded": {"method": "GET", "url": "me.svc"},
+            "onAllSucceeded": {"status-code": 200},
         }
-
-        coordinator = SagaCoordinator(configuration)
 
         with requests_mock.Mocker() as m:
             m.post("http://foo.svc/transact", status_code=200)
+            coordinator = SagaCoordinator(configuration)
             success, transactions, failed_compensations = coordinator.execute_saga()
             self.assertEqual(
                 ["http://foo.svc/transact"],
@@ -51,24 +51,274 @@ class TestSagaCoordinator(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.post("http://foo.svc/transact", status_code=404)
-            m.post("http://foo.svc/fail", status_code=200)
+            coordinator = SagaCoordinator(configuration)
             success, transactions, failed_compensations = coordinator.execute_saga()
             self.assertEqual(
-                ["http://foo.svc/transact", "http://foo.svc/fail"],
+                ["http://foo.svc/transact"],
+                [request.url for request in m.request_history],
+            )
+            self.assertFalse(success)
+            self.assertEqual(len(transactions), 0)
+            self.assertEqual(len(failed_compensations), 0)
+
+    def test_saga_sends_with_resolved_interpolations(self):
+        """
+        This test checks if the saga coordinator correctly handles inserting interpolating
+        message values before they are sent.
+
+        Interpolation semantics can be tricky. 
+
+        Here's a rough guide of what to expect:
+
+            - An interpolation is an expression of the form ${EXPR[:DEFAULT]} inserted into another string. The expression
+              will then be evaluated by the coordinator right before sending.
+
+            - An interpolation can only appear in an HTTP_REQUEST_SCHEMA type. It can only appear in the `url`,
+              in the values of `header` entries, and in the `body`. 
+
+            - An HTTP_REQUEST_SCHEMA can request the following attributes to be interpolated:
+
+                - For any transaction in `onMatchedRequest`, the headers and body of the `matchRequest`. 
+                  Accessed by EXPR set to `parent.headers.<HEADER>` or `parent.body`.
+
+                - In `onFailure`, the headers and body of the transaction request. 
+                  Accessed by EXPR set to `parent.headers.<HEADER>` or `parent.body`.
+
+                - In `onFailure`, the headers and body of the transaction response that prompted a failure. 
+                  Accessed by EXPR set to `parent.response.headers.<HEADER>` and `parent.response.body`. If the 
+                  response does not exist (say, because of timeouts and maxRetriesOnTimeout), an empty string
+                  will be inserted. If DEFAULT is specified, then DEFAULT will be inserted.
+
+                -  In `isSuccessIfReceives`, the headers and body of the transaction request. 
+                  Accessed by EXPR set to `parent.headers.<HEADER>` or `parent.body`.
+
+                - In `onAllSucceeded`, the responses and requests for each transaction (not compensating transactions).
+                  Accessed by EXPR set to `transaction[N].request.headers.<header>`, `transaction[N].request.body`, \
+                  `transaction[N].response.headers.<header>` or `transaction[N].response.body`. N here is zero-indexed array index,
+                  and refers to the corresponding Nth transaction in `onMatchRequest`.
+
+                - In `onAnyFailed`, the responses and requests for each transaction (not compensating transactions).
+                  Accessed by EXPR set to `transaction[N].request.headers.<header>`, `transaction[N].request.body`, \
+                  `transaction[N].request.headers.<header>` or `transaction[N].response.body`. N here is zero-indexed array index,
+                  and refers to the corresponding Nth transaction in `onMatchRequest`. If any of these transactions were cancelled,
+                  the corresponding interpolation string will evalute to an empty string - use DEFAULT instead. 
+        """
+
+        configuration = {
+            "host": "me.svc",
+            "matchRequest": {
+                "method": "GET",
+                "url": "http://localhost:20000",
+                "headers": {"Start-Faking": "True"},
+            },
+            "onMatchedRequest": [
+                {
+                    "method": "POST",
+                    "url": "http://ratings.svc/add/${parent.headers.PRODUCT-ID}",
+                    "headers": {
+                        "MY_HEADER": "${parent.headers.PRODUCT-ID}",
+                        "MY_OTHER_HEADER": "LIFE",
+                    },
+                    "isSuccessIfReceives": [{"status-code": 200, "body": "success"}],
+                    "onFailure": [
+                        {
+                            "method": "POST",
+                            "url": "http://ratings.svc/delete/${root.headers.PRODUCT-ID}",
+                            "headers": {
+                                "SHOULD_EXIST": "${parent.headers.MY_OTHER_HEADER}",
+                                "SHOULD_NOT_EXIST": "${parent.headers.FOO:laaa}",
+                            },
+                            "timeout": 3,
+                            "maxRetriesOnTimeout": 1,
+                            "isSuccessIfReceives": [{"status-code": 200}],
+                        }
+                    ],
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 3,
+                }
+            ],
+            "onAllSucceeded": {"status-code": 200},
+            "onAnyFailed": {"status-code": 200},
+        }
+
+        start_request_headers = {"PRODUCT-ID": "12"}
+
+        with requests_mock.Mocker() as m:
+            m.post("http://ratings.svc/add/12", status_code=200, text="success")
+            coordinator = SagaCoordinator(
+                configuration, start_request_headers=start_request_headers
+            )
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                ["http://ratings.svc/add/12"],
+                [request.url for request in m.request_history],
+            )
+            self.assertEqual("12", m.request_history[0].headers["MY_HEADER"])
+            self.assertTrue(success)
+            self.assertEqual(len(transactions), 1)
+            self.assertEqual(len(failed_compensations), 0)
+
+        with requests_mock.Mocker() as m:
+            m.post("http://ratings.svc/add/12", status_code=404)
+            coordinator = SagaCoordinator(
+                configuration, start_request_headers=start_request_headers
+            )
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                ["http://ratings.svc/add/12"],
+                [request.url for request in m.request_history],
+            )
+            self.assertEqual("12", m.request_history[0].headers["MY_HEADER"])
+            self.assertFalse(success)
+            self.assertEqual(len(transactions), 0)
+            self.assertEqual(len(failed_compensations), 0)
+
+    def test_saga_executes_with_resolved_interpolations_for_real_configuration(self):
+        configuration = {
+            "host": "productpage.svc",
+            "matchRequest": {
+                "method": "GET",
+                "url": "http://localhost:3001",
+                "headers": {"Start-Faking": "True"},
+            },
+            "onMatchedRequest": [
+                {
+                    "method": "GET",
+                    "url": "http://ratings.svc/add/${parent.headers.Product-Id}",
+                    "isSuccessIfReceives": [
+                        {
+                            "status-code": 200,
+                            "headers": {"Content-type": "application/json"},
+                        }
+                    ],
+                    "onFailure": [
+                        {
+                            "method": "GET",
+                            "url": "http://ratings.svc/delete/${root.headers.Product-Id}",
+                            "timeout": 3,
+                            "maxRetriesOnTimeout": 1,
+                            "isSuccessIfReceives": [
+                                {
+                                    "status-code": 200,
+                                    "headers": {"Content-type": "application/json"},
+                                }
+                            ],
+                        }
+                    ],
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 3,
+                },
+                {
+                    "method": "GET",
+                    "url": "http://details.svc/details/add/${root.headers.Product-Id}",
+                    "isSuccessIfReceives": [
+                        {
+                            "status-code": 200,
+                            "headers": {"Content-type": "application/json"},
+                        }
+                    ],
+                    "onFailure": [
+                        {
+                            "method": "GET",
+                            "url": "http://details.svc/details/remove/${root.headers.Product-Id}",
+                            "timeout": 3,
+                            "maxRetriesOnTimeout": 1,
+                            "isSuccessIfReceives": [
+                                {
+                                    "status-code": 200,
+                                    "headers": {"Content-type": "application/json"},
+                                }
+                            ],
+                        }
+                    ],
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 3,
+                },
+            ],
+            "onAllSucceeded": {
+                "status-code": 200,
+                "body": "Ratings: ${transaction[0].response.body}\nDetails: ${transaction[1].response.body}\n",
+            },
+            "onAnyFailed": {
+                "status-code": 500,
+                "body": "Ratings: ${transaction[0].response.body}\nDetails: ${transaction[1].response.body}\n",
+            },
+        }
+
+        start_request_headers = {"Product-Id": "12"}
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://ratings.svc/add/12",
+                status_code=200,
+                headers={"Content-type": "application/json"},
+                text="bar",
+            )
+            m.get(
+                "http://details.svc/details/add/12",
+                status_code=200,
+                headers={"Content-type": "application/json"},
+                text="foo",
+            )
+            coordinator = SagaCoordinator(
+                configuration, start_request_headers=start_request_headers
+            )
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                ["http://ratings.svc/add/12", "http://details.svc/details/add/12"],
+                [request.url for request in m.request_history],
+            )
+            self.assertTrue(success)
+            self.assertEqual(len(transactions), 2)
+            self.assertEqual(len(failed_compensations), 0)
+
+            context = {
+                "parent": RequestNode(),
+                "root": coordinator.root,
+                "transactions": transactions,
+            }
+
+            out = interpolate(configuration["onAllSucceeded"]["body"], **context)
+            self.assertEqual("Ratings: bar\nDetails: foo\n", out)
+
+        with requests_mock.Mocker() as m:
+            m.get("http://ratings.svc/add/12", status_code=403)
+            coordinator = SagaCoordinator(
+                configuration, start_request_headers=start_request_headers
+            )
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                ["http://ratings.svc/add/12"],
+                [request.url for request in m.request_history],
+            )
+            self.assertFalse(success)
+            self.assertEqual(len(transactions), 0)
+            self.assertEqual(len(failed_compensations), 0)
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://ratings.svc/add/12",
+                status_code=200,
+                headers={"Content-type": "application/json"},
+            )
+            m.get(
+                "http://ratings.svc/delete/12",
+                status_code=200,
+                headers={"Content-type": "application/json"},
+            )
+            m.get("http://details.svc/details/add/12", status_code=404)
+            coordinator = SagaCoordinator(
+                configuration, start_request_headers=start_request_headers
+            )
+            success, transactions, failed_compensations = coordinator.execute_saga()
+            self.assertEqual(
+                [
+                    "http://ratings.svc/add/12",
+                    "http://details.svc/details/add/12",
+                    "http://ratings.svc/delete/12",
+                ],
                 [request.url for request in m.request_history],
             )
             self.assertFalse(success)
             self.assertEqual(len(transactions), 1)
             self.assertEqual(len(failed_compensations), 0)
-
-        with requests_mock.Mocker() as m:
-            m.post("http://foo.svc/transact", status_code=404)
-            m.post("http://foo.svc/fail", status_code=403)
-            success, transactions, failed_compensations = coordinator.execute_saga()
-            self.assertEqual(
-                ["http://foo.svc/transact", "http://foo.svc/fail"],
-                [request.url for request in m.request_history],
-            )
-            self.assertFalse(success)
-            self.assertEqual(len(transactions), 1)
-            self.assertEqual(len(failed_compensations), 1)

--- a/src/test_server.py
+++ b/src/test_server.py
@@ -1,0 +1,165 @@
+import io
+import yaml
+import requests
+import unittest
+import requests_mock
+from server import RequestHandler
+from unittest.mock import patch, mock_open
+from requests_toolbelt.utils import dump
+from scapy.layers.http import HTTP, HTTPResponse, HTTPRequest
+
+
+class TestableHandler(RequestHandler):
+    def setup(self):
+        self.rfile = io.BytesIO(self.request)
+        self.wfile = None
+
+    def finish(self):
+        pass
+
+    def handle(self):
+        pass
+
+    def test(self, wfile):
+        self.wfile = wfile
+        self.handle_one_request()
+
+
+class HTTPRequestHandlerTestCase(unittest.TestCase):
+    def test_proxy_behaviour(self):
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://foo.svc",
+                status_code=200,
+                headers={"Content-Type": "application/json"},
+                text="success",
+            )
+
+            raw = dump.dump_response(
+                requests.get("http://foo.svc"),
+                request_prefix="",
+                response_prefix="@@@",
+            )
+            split = raw.split(b"@@@")
+            raw_request = split[0]
+            expected_response = HTTPResponse(b"".join(split[1:]))
+
+            raw_request
+            handler = TestableHandler(raw_request, (0, 0), None)
+
+            write_file = io.BytesIO()
+            handler.test(write_file)
+            write_file.seek(0)
+
+            response = HTTPResponse(write_file.read())
+
+            self.assertEqual(response.Status_Code, expected_response.Status_Code)
+            self.assertEqual(response.Content_Type, expected_response.Content_Type)
+            self.assertEqual(response.load, expected_response.load)
+
+    def test_saga_behaviour(self):
+
+        configuration = {
+            "host": "productpage.svc",
+            "matchRequest": {
+                "method": "GET",
+                "url": "http://localhost:3001/",
+                "headers": {"Start-Faking": "True"},
+            },
+            "onMatchedRequest": [
+                {
+                    "method": "GET",
+                    "url": "http://ratings.svc/add/${parent.headers.Product-Id}",
+                    "isSuccessIfReceives": [
+                        {
+                            "status-code": 200,
+                            "headers": {"Content-type": "application/json"},
+                        }
+                    ],
+                    "onFailure": [
+                        {
+                            "method": "GET",
+                            "url": "http://ratings.svc/delete/${root.headers.Product-Id}",
+                            "timeout": 3,
+                            "maxRetriesOnTimeout": 1,
+                            "isSuccessIfReceives": [
+                                {
+                                    "status-code": 200,
+                                    "headers": {"Content-type": "application/json"},
+                                }
+                            ],
+                        }
+                    ],
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 3,
+                },
+                {
+                    "method": "GET",
+                    "url": "http://details.svc/details/add/${root.headers.Product-Id}",
+                    "isSuccessIfReceives": [
+                        {
+                            "status-code": 200,
+                            "headers": {"Content-type": "application/json"},
+                        }
+                    ],
+                    "onFailure": [
+                        {
+                            "method": "GET",
+                            "url": "http://details.svc/details/remove/${root.headers.Product-Id}",
+                            "timeout": 3,
+                            "maxRetriesOnTimeout": 1,
+                            "isSuccessIfReceives": [
+                                {
+                                    "status-code": 200,
+                                    "headers": {"Content-type": "application/json"},
+                                }
+                            ],
+                        }
+                    ],
+                    "timeout": 30,
+                    "maxRetriesOnTimeout": 3,
+                },
+            ],
+            "onAllSucceeded": {
+                "status-code": 200,
+                "body": "Ratings: ${transaction[0].response.body}\nDetails: ${transaction[1].response.body}\n",
+            },
+            "onAnyFailed": {
+                "status-code": 500,
+                "body": "Ratings: ${transaction[0].response.body}\nDetails: ${transaction[1].response.body}\n",
+            },
+        }
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://ratings.svc/add/12",
+                status_code=200,
+                headers={"Content-type": "application/json"},
+                text="success",
+            )
+            m.get(
+                "http://details.svc/details/add/12",
+                status_code=200,
+                headers={"Content-type": "application/json"},
+                text="success again",
+            )
+
+            raw_request = b"GET / HTTP/1.1\r\nHost: http://localhost:3001\r\nUser-Agent: python-requests/2.9.1\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nStart-Faking: True\r\nProduct-Id: 12\r\n\r\n"
+
+            with patch(
+                "builtins.open", mock_open(read_data=yaml.dump(configuration))
+            ) as mock_file:
+
+                with patch("os.path.exists") as os_mock:
+                    os_mock.return_value = True
+                    handler = TestableHandler(raw_request, (0, 0), None)
+
+                    write_file = io.BytesIO()
+                    handler.test(write_file)
+                    write_file.seek(0)
+
+                    response = HTTPResponse(write_file.read())
+                    self.assertEqual(response.Status_Code, b"200")
+                    self.assertEqual(
+                        response.load, b"Ratings: success\nDetails: success again\n"
+                    )


### PR DESCRIPTION
Couple of major changes here:

1. Removed `asyncio` in favour of a simple threading HTTP server.
`asyncio` is too complicated for our simple synchronous needs, and we
can always move to an asyncio frontend if performance becomes critical.

2. Renamed several class names, such as `ConfigurationManager` ->
`ConfigurationStore`. This is just for clarity of purpose.

3. Introduces a template language for interpolation. This language
supports grabbing headers and data from the root (read: the initial
request sent to qbox), from parents (read: any request/response that was
the direct trigger of this message), and from transactions (the
request/response pair of any transaction). I eschewed supporting being
able to read from compensating transaction request/response pair as I
could not foresee a usecase. Not all of these interpolation templates
work in every context - for examples, transaction data is not accessible
until `onAnyFailed` or `onAllSucceeded`.

4. To implement interpolation, I moved to a model where requests and
their response are encapsulated by a `RequestNode` object, and where
these objects form a tree hierarchy starting from the initialization
saga request. This greatly simplifies interpolation logic - rather than
separately maintain headers and bodies of both response and request, one
can simply feed the corresponding `RequestNode` object as the source for
all subsequent interpoldation data. Additionally, one can supply a list
of `RequestNode`s modelling transactions to the interpolation function.

5. I made changes to the configuration schema in some places, for
example replacing `onAnySucceeded`'s value from HTTP_REQUEST_SCHEMA to
HTTP_RESPONSE_SCHEMA. This is because the mental model became clearer
during development, in that we will not be issuing new requests in those
keys but are instead simply replying back to the original request.

6. Added tests for interpolation. These are not very extensive at all.

7. Added tests for our HTTP server, both in proxy mode and for saga
initialization requests. These both pass for now.

8. I made a meaningful semantic change to `onFailure`. Previously, we
would issue `onFailure` messages for the transaction that had just
failed. However, this doesn't actually make sense - we should only send
compensating transactions to the transactions that have *successfully*
completed, so that they can release the resources they are holding on
our behalf.