### PR TITLE
extend to support multi-document configuration parsing

### DIFF
--- a/src/configuration.py
+++ b/src/configuration.py
@@ -106,12 +106,12 @@ class ConfigurationStore(object):
 
     def __init__(self):
 
-        self.config = {}
+        self.config = []
 
         if os.path.exists(CONFIGURATION_PATH):
             with open(CONFIGURATION_PATH) as config:
-                self.config = ROOT_SCHEMA.validate(yaml.load(config))
+                for c in yaml.safe_load_all(config):
+                    self.config.append(ROOT_SCHEMA.validate(c))
 
     def get_config(self):
-
         return self.config

--- a/src/server.py
+++ b/src/server.py
@@ -56,71 +56,75 @@ class RequestHandler(SimpleHTTPRequestHandler):
 
     def handle_connection(self):
         logging.info(f"Handling request {self.headers} {self.get_body()}")
-        if self.configuration and self.is_saga_request():
-            logging.info("Identified a transaction request!")
-            status, headers, body = self.execute()
-            self.send_response(status)
-            for header, value in headers.items():
-                self.send_header(header, value)
-            self.end_headers()
-            self.wfile.write(body.encode("utf-8"))
-        else:
-            logging.info("Decided it was not a transaction")
-            url = self.headers["Host"]
-            try:
-                logging.info(f"Sending request to {url}")
-                response = requests.request(
-                    method=self.command,
-                    # NOTE: We're assuming HTTPS traffic is never sent to us!
-                    # This is fine for our proof-of-concept - Envoy in practice
-                    # automatically upgrades all HTTP traffic to HTTPS if configured
-                    # to do so with the appropriate TLS certificates.
-                    url=url if url.startswith("http://") else f"http://{url}",
-                    headers=self.headers,
-                    data=self.get_body(),
-                    proxies={"http": ENVOY_ADDRESS, "https": ENVOY_ADDRESS},
-                )
-                logging.info(f"Got response back of {response.status_code}")
-                self.send_response(response.status_code)
-                for header, value in response.headers.items():
+        if self.configuration:
+            res = self.is_saga_request()
+            if res[0]:
+                logging.info("Identified a transaction request!")
+                status, headers, body = self.execute(res[1])
+                self.send_response(status)
+                for header, value in headers.items():
                     self.send_header(header, value)
                 self.end_headers()
-                self.wfile.write(response.content)
-            except Exception as e:
-                self.send_error(599, "Error proxying: {}".format(e))
+                self.wfile.write(body.encode("utf-8"))
+                return
+        
+        logging.info("Decided it was not a transaction")
+        url = self.headers["Host"]
+        try:
+            logging.info(f"Sending request to {url}")
+            response = requests.request(
+                method=self.command,
+                # NOTE: We're assuming HTTPS traffic is never sent to us!
+                # This is fine for our proof-of-concept - Envoy in practice
+                # automatically upgrades all HTTP traffic to HTTPS if configured
+                # to do so with the appropriate TLS certificates.
+                url=url if url.startswith("http://") else f"http://{url}",
+                headers=self.headers,
+                data=self.get_body(),
+                proxies={"http": ENVOY_ADDRESS, "https": ENVOY_ADDRESS},
+            )
+            logging.info(f"Got response back of {response.status_code}")
+            self.send_response(response.status_code)
+            for header, value in response.headers.items():
+                self.send_header(header, value)
+            self.end_headers()
+            self.wfile.write(response.content)
+        except Exception as e:
+            self.send_error(599, "Error proxying: {}".format(e))
 
     def is_saga_request(self):
 
         logging.info("Checking if Saga request...")
+        for c, i in enumerate(self.configuration):
+            config = c["matchRequest"]
+            headers = config.get("headers", {})
+            body = config.get("body", "")
 
-        config = self.configuration["matchRequest"]
-        headers = config.get("headers", {})
-        body = config.get("body", "")
+            constructed_url = f"{self.headers['Host']}{self.path}"
+            if not constructed_url.startswith("http://"):
+                constructed_url = f"http://{constructed_url}"
 
-        constructed_url = f"{self.headers['Host']}{self.path}"
-        if not constructed_url.startswith("http://"):
-            constructed_url = f"http://{constructed_url}"
+            if config["url"] != constructed_url:
+                continue
+            if config["method"] != self.command:
+                continue
+            if headers and any(
+                self.headers.get(header) != value for header, value in headers.items()
+            ):
+                continue
+            if body and self.get_body() != body:
+                continue
 
-        if config["url"] != constructed_url:
-            return False
-        if config["method"] != self.command:
-            return False
-        if headers and any(
-            self.headers.get(header) != value for header, value in headers.items()
-        ):
-            return False
-        if body and self.get_body() != body:
-            return False
+            return (True, i)
+        return (False, None)
 
-        return True
-
-    def execute(self):
+    def execute(self, i):
         """
         Handle all requests as deemed necessary.
         """
 
         coordinator = SagaCoordinator(
-            self.configuration,
+            self.configuration[i],
             start_request_headers=self.headers,
             start_request_body=self.get_body(),
         )
@@ -132,9 +136,9 @@ class RequestHandler(SimpleHTTPRequestHandler):
         }
 
         if success:
-            return self.respond(self.configuration["onAllSucceeded"], context)
+            return self.respond(self.configuration[i]["onAllSucceeded"], context)
         else:
-            return self.respond(self.configuration["onAnyFailed"], context)
+            return self.respond(self.configuration[i]["onAnyFailed"], context)
 
     def respond(self, config, context):
 

--- a/src/test_configuration.py
+++ b/src/test_configuration.py
@@ -159,6 +159,8 @@ class TestConfigurationManager(unittest.TestCase):
         "onAnyFailed": {"status-code": 200},
     }
 
+    multiroots = [validRoot, validRoot]
+
     def test_get_config(self):
 
         with patch(
@@ -167,8 +169,34 @@ class TestConfigurationManager(unittest.TestCase):
 
             with patch("os.path.exists") as os_mock:
                 os_mock.return_value = True
-                configuration = ConfigurationStore().get_config()
+                configurations = ConfigurationStore().get_config()
 
             mock_file.assert_called_with(CONFIGURATION_PATH)
+
+            self.assertTrue(len(configurations), 1)
+
+            configuration = configurations[0]
+            self.assertIn("matchRequest", configuration)
+            self.assertIn("onMatchedRequest", configuration)
+
+    def test_get_multiple_config(self):
+
+        with patch(
+            "builtins.open", mock_open(read_data=yaml.dump_all(self.multiroots))
+        ) as mock_file:
+
+            with patch("os.path.exists") as os_mock:
+                os_mock.return_value = True
+                configurations = ConfigurationStore().get_config()
+
+            mock_file.assert_called_with(CONFIGURATION_PATH)
+
+            self.assertTrue(len(configurations), 2)
+
+            configuration = configurations[0]
+            self.assertIn("matchRequest", configuration)
+            self.assertIn("onMatchedRequest", configuration)
+
+            configuration = configurations[1]
             self.assertIn("matchRequest", configuration)
             self.assertIn("onMatchedRequest", configuration)


### PR DESCRIPTION
4 changes to support multi-document configuration file parsing:
1)  In `configuration.py`, use `yaml.safe_load_all()` to load all documents and use Schema to parse every document. Note that ConfigurationStore.config becomes a list of configurations.
2) In `server.py`, `RequestHandler.is_saga_request()` matches every configuration and returns a tuple indicating whether there is a match and what is the index.
3) Minor change of `RequestHandler.handle_connection()` to make it compatible with `is_saga_request`
4) `RequestHandler.excute()` now takes one argument indicating the index of configuration to create the coordinator